### PR TITLE
chore(paropt_manager): add job exc_info to jobToDict

### DIFF
--- a/paropt_service/api/paropt_manager.py
+++ b/paropt_service/api/paropt_manager.py
@@ -150,7 +150,8 @@ class ParoptManager():
         'job_id': job.get_id(),
         'job_status': job.get_status(),
         'job_result': job.result,
-        'job_meta': job.meta
+        'job_meta': job.meta,
+        'job_exc_info': job.exc_info
       }
   
   @classmethod


### PR DESCRIPTION
## Changes
- add `job_exc_info` to jobToDict, allowing us to see the exception that caused jobs to fail