### PR TITLE
chore(start_compose): export logs path

### DIFF
--- a/start_compose.sh
+++ b/start_compose.sh
@@ -3,6 +3,12 @@
 # Helper for running docker compose
 #
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  export PAROPT_HOST_LOGS=~/Library/Logs/paropt/
+else
+  export PAROPT_HOST_LOGS=/var/log/paropt/
+fi
+
 if [[ $1 =~ prod$ ]]; then
   paropt_env="prod"
   shift


### PR DESCRIPTION
## Changes
- export PAROPT_HOST_LOGS (path to save logs on host) in the start compose helper script