### PR TITLE
chore(requirements): pin parsl 0.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Ted Summer <ted.summer2@gmail.com>"
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update
-RUN apt-get install -y git-core curl
+RUN apt-get install -y gcc git-core curl
 
 # get miniconda
 RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o ~/miniconda.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ flask==1.0.2
 globus-sdk
 psycopg2-binary==2.8.1
 pyopenssl
-parsl[aws]>=0.7.2
+parsl[aws]==0.8.0
 git+https://git@github.com/macintoshpie/paropt
 redis>=3.2.1
 # rq>=1.0
 git+https://git@github.com/macintoshpie/rq@patch-3
+

--- a/start_compose.sh
+++ b/start_compose.sh
@@ -3,10 +3,16 @@
 # Helper for running docker compose
 #
 
+
 if [[ "$(uname)" == "Darwin" ]]; then
   export PAROPT_HOST_LOGS=~/Library/Logs/paropt/
 else
   export PAROPT_HOST_LOGS=/var/log/paropt/
+fi
+
+if [[ $1 =~ build$ ]]; then
+  sudo -E docker-compose build --no-cache
+  exit $?
 fi
 
 if [[ $1 =~ prod$ ]]; then


### PR DESCRIPTION
## Changes
- pin parsl to 0.8.0
- add gcc to image for parsl

## New features
- added `--build` to start_compose.sh to rebuild image without using cache